### PR TITLE
Dispatcher: import encode_json_utf8

### DIFF
--- a/lib/Mojo/WebSocketProxy/Dispatcher.pm
+++ b/lib/Mojo/WebSocketProxy/Dispatcher.pm
@@ -9,7 +9,7 @@ use Mojo::WebSocketProxy::Config;
 
 use Class::Method::Modifiers;
 
-use JSON::MaybeUTF8;
+use JSON::MaybeUTF8 qw(encode_json_utf8);
 use Unicode::Normalize ();
 use Future::Mojo 0.004;    # ->new_timeout
 use Future::Utils qw(fmap);


### PR DESCRIPTION
Missing an explicit import of this sub from JSON::MaybeUTF8 would fallback to an AUTOLOAD here (via its Mojolicious::Controller parent,) which is not intended.