### PR TITLE
Really remove Data::UUID

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,6 @@ my %WriteMakefileArgs = (
   "NAME" => "Mojo::WebSocketProxy",
   "PREREQ_PM" => {
     "Class::Method::Modifiers" => 0,
-    "Data::UUID" => 0,
     "Future" => 0,
     "Guard" => 0,
     "JSON" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,4 @@
 requires 'Class::Method::Modifiers';
-requires 'Data::UUID';
 requires 'Future', '>= 0.36';
 requires 'Future::Mojo', '>= 0.004';
 requires 'indirect';


### PR DESCRIPTION
`Changes` notes this removal from 0.05, but it is still pulled in via cpanfile.