### PR TITLE
Dispatcher: normalize and decode WS_TEXT frames

### DIFF
--- a/lib/Mojo/WebSocketProxy/Dispatcher.pm
+++ b/lib/Mojo/WebSocketProxy/Dispatcher.pm
@@ -9,7 +9,7 @@ use Mojo::WebSocketProxy::Config;
 
 use Class::Method::Modifiers;
 
-use JSON::MaybeUTF8 qw(encode_json_utf8);
+use JSON::MaybeUTF8 qw(:v1);
 use Unicode::Normalize ();
 use Future::Mojo 0.004;    # ->new_timeout
 use Future::Utils qw(fmap);
@@ -64,7 +64,9 @@ sub open_connection {
         my ($c, $msg) = @_;
         # Incoming data will be JSON-formatted text, as a Unicode string.
         # We normalize the entire string before decoding.
-        my $args = eval { Mojo::JSON::decode_json(Unicode::Normalize::NFC($msg)) };
+        my $normalized_msg = Unicode::Normalize::NFC($msg);
+        my $args = eval { decode_json_utf8($normalized_msg) };
+        $log->error("JSON decoding $normalized_msg failed: $@") if $@;
         on_message($c, $args);
     });
 

--- a/lib/Mojo/WebSocketProxy/Dispatcher.pm
+++ b/lib/Mojo/WebSocketProxy/Dispatcher.pm
@@ -60,11 +60,11 @@ sub open_connection {
 
     $config->{opened_connection}->($c) if $config->{opened_connection};
 
-    $c->on(message => sub {
+    $c->on(text => sub {
         my ($c, $msg) = @_;
         # Incoming data will be JSON-formatted text, as a Unicode string.
         # We normalize the entire string before decoding.
-        my $args = Mojo::JSON::decode_json(Unicode::Normalize::NFC($msg));
+        my $args = eval { Mojo::JSON::decode_json(Unicode::Normalize::NFC($msg)) };
         on_message($c, $args);
     });
 


### PR DESCRIPTION
Mojo::Transaction::WebSockets emits `message` events with text frames preprocessed with Mojo::Util::decode, which renders any Unicode::Normalize work into no-ops.

    10> Mojo::Util::decode "UTF-8", "{\"ping\":\"\x{bf0}\"}"
    $res[4] = undef
    11> Mojo::Util::encode "UTF-8", "{\"ping\":\"\x{bf0}\"}"
    $res[5] = "{"ping":"௰"}"

Prevent this by subscribing to `text` events instead, which does not do any any preprocessing of the text frame.

Also catch possible exceptions from the JSON decoding, in a similar vein to the default `json` event.