### PR TITLE
Dispatcher: censor messages failing JSON decoding

### DIFF
--- a/lib/Mojo/WebSocketProxy/Dispatcher.pm
+++ b/lib/Mojo/WebSocketProxy/Dispatcher.pm
@@ -65,9 +65,12 @@ sub open_connection {
         # Incoming data will be JSON-formatted text, as a Unicode string.
         # We normalize the entire string before decoding.
         my $normalized_msg = Unicode::Normalize::NFC($msg);
-        my $args = eval { decode_json_utf8($normalized_msg) };
-        $log->error("JSON decoding $normalized_msg failed: $@") if $@;
-        on_message($c, $args);
+        if (my $args = eval { decode_json_utf8($normalized_msg) }) {
+            on_message($c, $args);
+        } else {
+            $c->finish(1007 => 'Malformed JSON');
+            $log->debug(qq{JSON decoding failed for "$normalized_msg": $@});
+        }
     });
 
     $c->on(binary => sub {

--- a/t/05_basic.t
+++ b/t/05_basic.t
@@ -110,20 +110,6 @@ is_deeply $res,
     },
     'It should return error response if action does not exist';
 
-$t = $t->send_ok({json => 'not_json'})->message_ok;
-$res = decode_json_utf8($t->message->[1]);
-is_deeply $res,
-    {
-    'error' => {
-        'code'    => 'BadRequest',
-        'message' => 'The application sent an invalid request.'
-    },
-    'debug'    => 1,
-    'msg_type' => 'error'
-    },
-    'It should return error response if bad request';
-
-
 $t = $t->send_ok({json => {some_action1 => 1}})->message_ok;
 $res = decode_json_utf8($t->message->[1]);
 ok $res->{some_action1}, 'Should return success';

--- a/t/14-bad-request.t
+++ b/t/14-bad-request.t
@@ -28,8 +28,7 @@ package t::FrontEnd {
 test_wsp {
     my ($t) = @_;
     $t->websocket_ok('/api' => {});
-    $t->send_ok({json => 'invalid'})->message_ok;
-    is(decode_json_utf8($t->message->[1])->{"error"}->{"code"}, 'BadRequest');
+    $t->send_ok({json => 'invalid'})->finished_ok(1007);
 } 't::FrontEnd';
 
 done_testing;


### PR DESCRIPTION
Fail the WebSocket connection immediately when receiving malformed input; log received messages on debug logging (if that level is active.)

Remove redundant test in t/05_basic.t as well, as this is covered now in t/14-bad-request.t.

https://tools.ietf.org/html/rfc6455#section-7.1.7