### PR TITLE
v0.10

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,12 @@ Revision history for Perl module Mojo::WebSocketProxy
 
 {{$NEXT}}
 
+0.10      2018-08-14 12:40:37+08:00 Asia/Manila
+    - Censor messages failing JSON decoding on Dispatcher::open_connection(),
+      moving these from error logging to debug logging to prevent leaking
+      private information, as well as dropping the WebSocket connection
+      entirely.
+
 0.09      2018-08-01 10:09:57+08:00 Asia/Manila
     - Fix character encoding issues on Dispatcher::open_connection() due
       to Mojo::Transaction::WebSockets emitting JSON-decoded `message` events;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,7 +47,7 @@ my %WriteMakefileArgs = (
     "Test::CheckDeps" => "0.010",
     "Test::More" => "0.94"
   },
-  "VERSION" => "0.09",
+  "VERSION" => "0.10",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/lib/Mojo/WebSocketProxy.pm
+++ b/lib/Mojo/WebSocketProxy.pm
@@ -3,7 +3,7 @@ package Mojo::WebSocketProxy;
 use strict;
 use warnings;
 
-our $VERSION = '0.09';
+our $VERSION = '0.10';
 
 1;
 


### PR DESCRIPTION
Courtesy PR for https://metacpan.org/release/BINARY/Mojo-WebSocketProxy-0.10

    - Censor messages failing JSON decoding on Dispatcher::open_connection(),
      moving these from error logging to debug logging to prevent leaking
      private information, as well as dropping the WebSocket connection
      entirely.