### PR TITLE
v0.11

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl module Mojo::WebSocketProxy
 
 {{$NEXT}}
 
+0.11      2018-08-15 13:03:25+08:00 Asia/Manila
+    - Fix test dependencies (switching from build phase,) adding Path::Tiny.
+
 0.10      2018-08-14 12:40:37+08:00 Asia/Manila
     - Censor messages failing JSON decoding on Dispatcher::open_connection(),
       moving these from error logging to debug logging to prevent leaking

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,15 +9,6 @@ use ExtUtils::MakeMaker 7.1101;
 my %WriteMakefileArgs = (
   "ABSTRACT" => "WebSocket proxy for JSON-RPC 2.0 server",
   "AUTHOR" => "binary.com <BINARY\@cpan.org>",
-  "BUILD_REQUIRES" => {
-    "Test::Fatal" => 0,
-    "Test::MockModule" => 0,
-    "Test::MockObject" => 0,
-    "Test::Mojo" => 0,
-    "Test::More" => "0.94",
-    "Test::Simple" => "0.44",
-    "Test::TCP" => 0
-  },
   "CONFIGURE_REQUIRES" => {
     "ExtUtils::MakeMaker" => "7.1101"
   },
@@ -44,10 +35,17 @@ my %WriteMakefileArgs = (
     "File::Spec" => 0,
     "IO::Handle" => 0,
     "IPC::Open3" => 0,
+    "Path::Tiny" => 0,
     "Test::CheckDeps" => "0.010",
-    "Test::More" => "0.94"
+    "Test::Fatal" => 0,
+    "Test::MockModule" => 0,
+    "Test::MockObject" => 0,
+    "Test::Mojo" => 0,
+    "Test::More" => "0.98",
+    "Test::Simple" => "0.44",
+    "Test::TCP" => 0
   },
-  "VERSION" => "0.10",
+  "VERSION" => "0.11",
   "test" => {
     "TESTS" => "t/*.t"
   }
@@ -67,13 +65,14 @@ my %FallbackPrereqs = (
   "Job::Async" => 0,
   "MojoX::JSON::RPC" => 0,
   "Mojolicious" => "7.29",
+  "Path::Tiny" => 0,
   "Scalar::Util" => 0,
   "Test::CheckDeps" => "0.010",
   "Test::Fatal" => 0,
   "Test::MockModule" => 0,
   "Test::MockObject" => 0,
   "Test::Mojo" => 0,
-  "Test::More" => "0.94",
+  "Test::More" => "0.98",
   "Test::Simple" => "0.44",
   "Test::TCP" => 0,
   "Unicode::Normalize" => "1.25",

--- a/lib/Mojo/WebSocketProxy.pm
+++ b/lib/Mojo/WebSocketProxy.pm
@@ -3,7 +3,7 @@ package Mojo::WebSocketProxy;
 use strict;
 use warnings;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 1;
 


### PR DESCRIPTION
Courtesy PR for https://metacpan.org/release/BINARY/Mojo-WebSocketProxy-0.11

    - Fix test dependencies (switching from build phase,) adding Path::Tiny.